### PR TITLE
Feature/ogani58 Create Order day field for user orders

### DIFF
--- a/client/src/pages/member/History.js
+++ b/client/src/pages/member/History.js
@@ -4,7 +4,7 @@ import { apiGetOrderByAccount } from "../../apis/user";
 import { setOrders } from "../../store/user/userSlice";
 import PaginationPage from "../../components/pagination/PaginationPage";
 import { product } from "../../ultils/constants";
-
+import moment from "moment";
 const History = () => {
   const dispatch = useDispatch();
   const userId = useSelector((state) => state.user.userId);
@@ -17,8 +17,11 @@ const History = () => {
     const fetchOrders = async () => {
       try {
         const response = await apiGetOrderByAccount(userId);
-        dispatch(setOrders(response.data));
-        const totalOrders = response.data.length;
+        const sortedOrders = response.data.sort((a, b) => {
+          return new Date(b.createdAt) - new Date(a.createdAt);
+        });
+        dispatch(setOrders(sortedOrders));
+        const totalOrders = sortedOrders.length;
         setTotalPages(Math.ceil(totalOrders / pageSize));
       } catch (error) {
         console.error("Error fetching orders:", error);
@@ -51,6 +54,7 @@ const History = () => {
             <th className="py-2 border-r-2">Price</th>
             <th className="py-2 border-r-2">Quantity</th>
             <th className="py-2 border-r-2">Total</th>
+            <th className="py-2 border-r-2">Ordered day</th>
           </tr>
         </thead>
 
@@ -91,6 +95,10 @@ const History = () => {
                     {order.total+"💲"}
                   </td>
                 )}
+
+                <td className="text-center py-2">
+                {moment(order.createdAt)?.format("DD/MM/YYYY")}
+              </td>
               </tr>
             ))
           )}

--- a/client/src/pages/member/History.js
+++ b/client/src/pages/member/History.js
@@ -97,7 +97,7 @@ const History = () => {
                 )}
 
                 <td className="text-center py-2">
-                {moment(order.createdAt)?.format("DD/MM/YYYY")}
+                {moment(order.createdAt)?.format("DD/MM/YYYY / HH:mm")}
               </td>
               </tr>
             ))


### PR DESCRIPTION
* Description: Users need to check what date their order was placed.
* Details:
* - Use this [API](https://ogani-be-yd0t.onrender.com/swagger-ui#/orders/OrderController_getByAccountId) to check order day(order day is createdAt field on each object).
* - On UI, add "Ordered date" field and sort order history following the newest order.
![image](https://github.com/DuyThang7821/Fruits-store-online/assets/84755253/51c88b01-66b6-432e-ab30-6f05d46ed4a8)

